### PR TITLE
Added support for filesystem backups

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -37,6 +37,10 @@ class veeam_val::config (
   $blocksize       = $::veeam_val::blocksize,
   $compression     = $::veeam_val::compression,
   $objects         = $::veeam_val::objects,
+  $includedirs     = $::veeam_val::includedirs,
+  $excludedirs     = $::veeam_val::excludedirs,
+  $includemasks    = $::veeam_val::includemasks,
+  $excludemasks    = $::veeam_val::excludemasks,
   $points          = $::veeam_val::points,
 
   $postjob         = $::veeam_val::postjob,
@@ -135,16 +139,23 @@ class veeam_val::config (
       }
 
       # Create the backup job with the correct settings
-      if ($type != 'entire') {
+      if ($type == 'entire') {
         exec { 'create_job':
-          command => "${service_cmd} job create --name '${jobname}' --repoName '${reponame}' --postjob '${postjob}' --prejob '${prejob}' --compressionLevel ${compression} --maxPoints ${points} --objects '${objects}'",
+          command => "${service_cmd} job create --name '${jobname}' --repoName '${reponame}' --postjob '${postjob}' --prejob '${prejob}' --compressionLevel ${compression} --maxPoints ${points} --backupAllSystem'",
+          unless  => "${service_cmd} job list | /bin/grep -c ${jobname}",
+          require => Exec['create_repository'],
+        }
+      }
+      elsif ($type == 'file') {
+        exec { 'create_job':
+          command => "${service_cmd} job create fileLevel --name '${jobname}' --repoName '${reponame}' --postjob '${postjob}' --prejob '${prejob}' --compressionLevel ${compression} --maxPoints ${points} --includeDirs '${includedirs}' --excludeDirs '${excludedirs}' --includeMasks \"${includeMasks}\" --excludeMasks \"${excludeMasks}\"",
           unless  => "${service_cmd} job list | /bin/grep -c ${jobname}",
           require => Exec['create_repository'],
         }
       }
       else {
         exec { 'create_job':
-          command => "${service_cmd} job create --name '${jobname}' --repoName '${reponame}' --postjob '${postjob}' --prejob '${prejob}' --compressionLevel ${compression} --maxPoints ${points} --backupAllSystem'",
+          command => "${service_cmd} job create --name '${jobname}' --repoName '${reponame}' --postjob '${postjob}' --prejob '${prejob}' --compressionLevel ${compression} --maxPoints ${points} --objects '${objects}'",
           unless  => "${service_cmd} job list | /bin/grep -c ${jobname}",
           require => Exec['create_repository'],
         }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,12 +22,16 @@
 #   username      => Login for target authentication       (DEFAULT: none)
 #   password      => Password for target authentication    (DEFAULT: none)
 #
-#	type	   	  => File, volume or entire                (DEFAULT: none)
-#   jobname       => Job name                              (DEFAULT: none)
-# 	blocksize     => 256|512|1024|4096                     (DEFAULT: 4096)
-#	compression   => 0 ... 4                               (DEFAULT: 1)
-#	objects       => Objects to backup comma seperated	   (DEFAULT: none)
-#	points        => Number of restore points to keep      (DEFAULT: 7)
+#	type         => File, volume or entire                (DEFAULT: none)
+#   jobname    => Job name                              (DEFAULT: none)
+# 	blocksize  => 256|512|1024|4096                     (DEFAULT: 4096)
+#	compression  => 0 ... 4                               (DEFAULT: 1)
+#	objects      => Objects to backup comma seperated	   (DEFAULT: none)
+# includedirs => Files to back up comma separated   (DEFAULT: none)
+# excludedirs => Files to exclude from backup back up comma separated   (DEFAULT: none)
+# includemasks => File masks to back up comma separated   (DEFAULT: none)
+# excludemasks => File masks to exclude from backup comma separated   (DEFAULT: none)
+#	points       => Number of restore points to keep      (DEFAULT: 7)
 #
 #   postjob  	  => Postjob script path                   (DEFAULT: none)
 #   prejob        => Prejob script path                    (DEFAULT: none)
@@ -107,6 +111,10 @@ class veeam_val (
   $blocksize      = $::veeam_val::params::blocksize,
   $points         = $::veeam_val::params::points,
   $objects        = $::veeam_val::params::objects,
+  $includedirs    = $::veeam_val::params::includedirs,
+  $excludedirs    = $::veeam_val::params::excludedirs,
+  $includemasks   = $::veeam_val::params::includemasks,
+  $excludemasks   = $::veeam_val::params::excludemasks,
 
   $postjob        = $::veeam_val::params::postjob,
   $prejob         = $::veeam_val::params::prejob,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,6 +37,10 @@ class veeam_val::params {
   $blocksize      = 4096
   $compression    = 1
   $objects        = '/dev/sda'
+  $includedirs    = ''
+  $excludedirs    = ''
+  $includemasks   = ''
+  $excludemasks   = ''
   $points         = 7
 
   $postjob        = ''


### PR DESCRIPTION
This should handle any arguments used for file level backup, which was listed as a parameter with 
 the veeam_val::type of 'file' , but did not seem to be fully implemented.