### PR TITLE
Fixed regexp in os version check

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,10 +18,10 @@ class veeam_val::install {
         $pkg_os_suffix = 'fc'
 
         case $::operatingsystemrelease {
-          /23./: {
+          /^23\./: {
             $osversion = 23
           }
-          /24./: {
+          /^24\./: {
             $osversion = 24
           }
           default: {
@@ -32,10 +32,10 @@ class veeam_val::install {
         $pkg_os_suffix = 'el'
 
         case $::operatingsystemrelease {
-          /6./: {
+          /^6\./: {
             $osversion = 6
           }
-          /7./: {
+          /^7\./: {
             $osversion = 7
           }
           default: {


### PR DESCRIPTION
Old version matched any os release version containing tested number. For example 7.1260 would result $osversion = 6 as regexp "6." matches.